### PR TITLE
asciifolding filter added

### DIFF
--- a/src/main/conf/elasticsearch.yml
+++ b/src/main/conf/elasticsearch.yml
@@ -12,13 +12,16 @@ index:
                type: custom
                char_filter: [html_strip]
                tokenizer: standard
-               filter: [standard,lowercase,mica_nGram_filter]
+               filter: [standard,lowercase,mica_asciifolding_filter,mica_nGram_filter]
             mica_search_analyzer:
                type: custom
                char_filter: [html_strip]
                tokenizer: standard
-               filter: [standard,lowercase]
+               filter: [standard,lowercase,mica_asciifolding_filter]
         filter:
+            mica_asciifolding_filter:
+                type: asciifolding
+                preserve_original: true
             mica_nGram_filter:
                 type: nGram
                 min_gram: 2


### PR DESCRIPTION
[ASCII Folding Token Filter](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-asciifolding-tokenfilter.html) to index latin words correctly.